### PR TITLE
feat(diagnosis): Implement miette-based visualizer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "count-digits",
+ "miette",
  "thiserror",
  "yansi",
 ]
@@ -908,6 +909,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,6 +1043,23 @@ name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "cfg-if",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
 
 [[package]]
 name = "mime"
@@ -1177,6 +1201,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "owo-colors"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "papergrid"
@@ -1744,6 +1774,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1837,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "supports-color"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -1896,6 +1953,27 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2095,6 +2173,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/crates/diagnosis/Cargo.toml
+++ b/crates/diagnosis/Cargo.toml
@@ -4,10 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+# `RustcVisualizer`
 yansi = { version = "1.0.1", features = ["hyperlink"], optional = true }
 thiserror = { version = "1.0", optional = true }
 ahash = { version = "0.8.11", optional = true }
 count-digits = { version = "0.5.1", optional = true }
 
+# `MietteVisualizer`
+miette = { version = "7.2.0", features = [
+    "fancy-no-backtrace",
+], default-features = false, optional = true }
+
 [features]
 rustc = ["dep:yansi", "dep:thiserror", "dep:ahash", "dep:count-digits"]
+miette = ["dep:miette", "dep:thiserror"]

--- a/crates/diagnosis/src/diagnostic.rs
+++ b/crates/diagnosis/src/diagnostic.rs
@@ -1,6 +1,7 @@
 use crate::Span;
 
 /// A diagnostic.
+#[derive(Debug)]
 pub struct Diagnostic<'a> {
     /// The primary message of the diagnostic.
     pub message: &'a str,
@@ -50,7 +51,7 @@ impl<'a> Diagnostic<'a> {
 }
 
 /// The severity of a diagnostic.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug)]
 pub enum Severity<'a> {
     /// A critical error that prevents the program from doing job.
     Error,
@@ -61,6 +62,7 @@ pub enum Severity<'a> {
 }
 
 /// A hightlight attached to a diagnostic.
+#[derive(Debug)]
 pub struct Highlight<'a> {
     /// The source span of the highlight.
     pub span: &'a Span,

--- a/crates/diagnosis/src/visualizers/miette.rs
+++ b/crates/diagnosis/src/visualizers/miette.rs
@@ -1,0 +1,133 @@
+pub use miette;
+
+use crate::{Diagnostic, Highlight, Severity, Visualizer};
+
+#[derive(Debug, thiserror::Error)]
+pub enum MietteVisualizerError {
+    #[error("fmt error: {0}")]
+    Fmt(#[from] std::fmt::Error),
+
+    #[error("IO error: {0}")]
+    IO(#[from] std::io::Error),
+}
+
+pub struct MietteVisualizer<'a> {
+    handler: miette::GraphicalReportHandler,
+    source_name: &'a str,
+    source: &'a str,
+}
+
+impl<'a> MietteVisualizer<'a> {
+    pub fn new(source_name: &'a str, source: &'a str) -> Self {
+        Self {
+            handler: miette::GraphicalReportHandler::default(),
+            source_name,
+            source,
+        }
+    }
+
+    pub fn with_theme(mut self, theme: miette::GraphicalTheme) -> Self {
+        self.handler = self.handler.with_theme(theme);
+        self
+    }
+}
+
+impl<'a> Visualizer<'a> for MietteVisualizer<'a> {
+    type Error = MietteVisualizerError;
+
+    fn visualize(
+        &self,
+        diag: Diagnostic<'_>,
+        f: &mut impl std::io::Write,
+    ) -> Result<(), Self::Error> {
+        let better = BetterMietteDiagnostic::from_diag(diag, self.source, self.source_name);
+
+        let mut buf = String::new();
+
+        self.handler.render_report(&mut buf, &better)?;
+
+        write!(f, "{}", buf.trim_end())?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("idk")]
+struct BetterMietteDiagnostic<'a> {
+    message: &'a str,
+    code: Option<&'a str>,
+    severity: Severity<'a>,
+    help_messages: Vec<&'a str>,
+    highlights: Vec<Highlight<'a>>,
+    source_name: &'a str,
+    source_: &'a str,
+}
+
+impl<'a> BetterMietteDiagnostic<'a> {
+    fn from_diag(diag: Diagnostic<'a>, source_: &'a str, source_name: &'a str) -> Self {
+        Self {
+            message: diag.message,
+            code: diag.code,
+            severity: diag.severity,
+            help_messages: diag.help_messages,
+            highlights: diag.highlights,
+            source_name,
+            source_,
+        }
+    }
+}
+
+impl miette::Diagnostic for BetterMietteDiagnostic<'_> {
+    fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        Some(Box::new(self.code?))
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        Some(match self.severity {
+            Severity::Error => miette::Severity::Error,
+            Severity::Warning => miette::Severity::Warning,
+            Severity::Custom(_) => miette::Severity::Advice,
+        })
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        let help = self.help_messages.join("\n");
+
+        if help.is_empty() {
+            None
+        } else {
+            Some(Box::new(help))
+        }
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        None
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.source_)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        if self.highlights.is_empty() {
+            None
+        } else {
+            Some(Box::new(self.highlights.iter().map(|h| {
+                miette::LabeledSpan::new(
+                    h.message.map(ToString::to_string),
+                    h.span.start,
+                    h.span.end - h.span.start,
+                )
+            })))
+        }
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
+        None
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn miette::Diagnostic> {
+        None
+    }
+}

--- a/crates/diagnosis/src/visualizers/mod.rs
+++ b/crates/diagnosis/src/visualizers/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "miette")]
+pub mod miette;
 #[cfg(feature = "rustc")]
 pub mod rustc;


### PR DESCRIPTION
I hoped that i could use miette to print diagnostics until i finish our own visualizer, but miette's taste is so bad that i was only reassured that writing a custom renderer is the only way forward. Not even mentioning it's API. Would still be useful for others i guess (e.g. oxc uses it (somehow)).